### PR TITLE
Fix OSGi dependency errors

### DIFF
--- a/AgreementMaker-OSGi/AgreementMaker-BatchMode/pom.xml
+++ b/AgreementMaker-OSGi/AgreementMaker-BatchMode/pom.xml
@@ -35,6 +35,9 @@
 						<Export-Package>${bundle.namespace}.*</Export-Package>
 						<Import-Package>
 							!javax.xml.namespace,
+                            !javax.xml.parsers,
+                            !org.w3c.dom,
+                            !org.xml.sax,
                             am.app.mappingEngine.oneToOneSelection,
 							*
 						</Import-Package>

--- a/AgreementMaker-OSGi/AgreementMaker-Core/pom.xml
+++ b/AgreementMaker-OSGi/AgreementMaker-Core/pom.xml
@@ -88,6 +88,7 @@
 							!nu.xom,
 							!org.apache.geronimo.osgi.registry.api,
 							!org.jdom.*,
+                            !org.xml.sax.helpers,
 							org.osgi.*,
 							com.hp.hpl.*,
 							org.apache.log4j.*,
@@ -140,6 +141,7 @@
 	<!-- Put the OSGi manifest where Eclipse Plugin Development Environment (PDE) expects it. -->
 	<profiles>
 		<profile>
+            <id>m2e</id>
 			<activation>
 				<property>
 					<name>m2e.version</name>

--- a/AgreementMaker-OSGi/AgreementMaker-UIGlue/pom.xml
+++ b/AgreementMaker-OSGi/AgreementMaker-UIGlue/pom.xml
@@ -31,7 +31,12 @@
 						<Bundle-Version>${project.version}</Bundle-Version>
 						<Export-Package>${bundle.namespace}.*</Export-Package>
 						<Bundle-Activator>${bundle.namespace}.Activator</Bundle-Activator>
-						<Import-Package>*</Import-Package>
+						<Import-Package>
+							!javax.xml.parsers,
+							!org.w3c.dom,
+							!org.xml.sax,
+							*
+						</Import-Package>
 					</instructions>
 				</configuration>
 			</plugin>

--- a/AgreementMaker-OSGi/AgreementMaker-UserFeedback/pom.xml
+++ b/AgreementMaker-OSGi/AgreementMaker-UserFeedback/pom.xml
@@ -46,7 +46,13 @@
 							!javax.xml.namespace,
 							!com.ctc.wstx.stax,
 							!javax.xml.transform,
+                            !javax.xml.transform.sax,
+                            !javax.xml.transform.stream,
 							!javax.xml.stream,
+                            !javax.xml.parsers,
+                            !org.w3c.dom,
+                            !org.xml.sax,
+                            !org.w3c.dom.*,
 							*
 						</Import-Package>
 						<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>

--- a/AgreementMaker-OSGi/Matcher-LinkedOpenData/pom.xml
+++ b/AgreementMaker-OSGi/Matcher-LinkedOpenData/pom.xml
@@ -33,7 +33,12 @@
 						<Bundle-Version>${project.version}</Bundle-Version>
 						<Export-Package>${bundle.namespace}.*</Export-Package>
 						<Bundle-Activator>${bundle.namespace}.Activator</Bundle-Activator>
-						<Import-Package>*</Import-Package>
+						<Import-Package>
+							!javax.xml.parsers,
+							!org.w3c.dom,
+							!org.xml.sax,
+							*
+						</Import-Package>
 					</instructions>
 				</configuration>
 			</plugin>

--- a/AgreementMaker-OSGi/pom.xml
+++ b/AgreementMaker-OSGi/pom.xml
@@ -89,9 +89,8 @@
                 <artifactId>maven-pax-plugin</artifactId>
                 <version>1.6.0</version>
                 <configuration>
-                    <provision>
-                        <param>--platform=felix</param>
-                    </provision>
+                    <framework>felix</framework>
+                    <noDependencies>true</noDependencies>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Bundle dependency errors were caused because maven-bundle-plugin was importing packages that don't exist in any of our bundles.

Also, Pax Runner was provisioning all the dependencies that looked like OSGi bundles.  We don't need to do this because AgreementMaker-Core already bundles and exports all the packages we need.